### PR TITLE
Add 'src_dir' override for libraries

### DIFF
--- a/tools/project.py
+++ b/tools/project.py
@@ -518,11 +518,13 @@ def generate_build_ninja(config, build_config):
 
             lib, obj = result
             lib_name = lib["lib"]
+            src_dir = Path(lib.get("src_dir", config.src_dir))
 
             options = obj.options
             completed = obj.completed
 
-            unit_src_path = config.src_dir / options["source"]
+            unit_src_path = src_dir / options["source"]
+
             if not unit_src_path.exists():
                 if config.warn_missing_source or completed:
                     print(f"Missing source file {unit_src_path}")
@@ -873,7 +875,10 @@ def generate_objdiff_config(config, build_config):
             return
 
         lib, obj = result
-        unit_src_path = config.src_dir / obj.options["source"]
+        src_dir = Path(lib.get("src_dir", config.src_dir))
+
+        unit_src_path = src_dir / obj.options["source"]
+
         if not unit_src_path.exists():
             objdiff_config["units"].append(unit_config)
             return


### PR DESCRIPTION
This allows projects to specify external libraries more easily. 
Particularly useful for common libraries shared between decomp projects, enabling the use of submodules/subtrees to deduplicated decomp efforts