### PR TITLE
Expand options for outputting context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ objdiff.json
 orig/*/*
 !orig/*/.gitkeep
 /*.txt
-ctx.c
+*.ctx

--- a/.vscode.example/settings.json
+++ b/.vscode.example/settings.json
@@ -13,7 +13,12 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.associations": {
+        "*.c.ctx": "c",
+        "*.ctx": "cpp",
         "*.inc": "cpp"
+    },
+    "files.exclude": {
+        "*.ctx": true
     },
     "search.useIgnoreFiles": false,
     "search.exclude": {

--- a/configure.py
+++ b/configure.py
@@ -27,7 +27,7 @@ from tools.project import (
 # Game versions
 DEFAULT_VERSION = 0
 VERSIONS = [
-    "GAMEID",	# 0
+    "GAMEID",  # 0
 ]
 
 if len(VERSIONS) > 1:
@@ -66,6 +66,12 @@ parser.add_argument(
     dest="map",
     action="store_true",
     help="generate map file(s)",
+)
+parser.add_argument(
+    "--context",
+    dest="context",
+    action="store_true",
+    help="generate context file(s) for decomp.me",
 )
 parser.add_argument(
     "--debug",
@@ -111,6 +117,7 @@ config.build_dir = args.build_dir
 config.build_dtk_path = args.build_dtk
 config.compilers_path = args.compilers
 config.debug = args.debug
+config.generate_context = args.context
 config.generate_map = args.map
 config.sjiswrap_path = args.sjiswrap
 if not is_windows():
@@ -150,7 +157,7 @@ cflags_base = [
     "-RTTI off",
     "-fp_contract on",
     "-str reuse",
-	"-multibyte", # For Wii compilers, replace with `-enc SJIS`
+    "-multibyte",  # For Wii compilers, replace with `-enc SJIS`
     "-i include",
     f"-i build/{config.version}/include",
     f"-DVERSION={version_num}",
@@ -169,7 +176,7 @@ cflags_runtime = [
     "-str reuse,pool,readonly",
     "-gccinc",
     "-common off",
-	"-inline auto",
+    "-inline auto",
 ]
 
 # REL flags

--- a/tools/decompctx.py
+++ b/tools/decompctx.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ###
-# Generates a ctx.c file, usable for "Context" on https://decomp.me.
+# Generates a *.ctx file, usable for "Context" on https://decomp.me.
 #
 # Usage:
 #   python3 tools/decompctx.py src/file.cpp
@@ -20,54 +20,61 @@ src_dir = os.path.join(root_dir, "src")
 include_dir = os.path.join(root_dir, "include")
 
 include_pattern = re.compile(r'^#include\s*[<"](.+?)[>"]$')
-guard_pattern = re.compile(r'^#ifndef\s+(.*)$')
+guard_pattern = re.compile(r"^#ifndef\s+(.*)$")
 
-defines = set()
+defines = set[str]()
+quiet = False
+
 
 def import_h_file(in_file: str, r_path: str) -> str:
     rel_path = os.path.join(root_dir, r_path, in_file)
     inc_path = os.path.join(include_dir, in_file)
     if os.path.exists(rel_path):
-      return import_c_file(rel_path)
+        return import_c_file(rel_path)
     elif os.path.exists(inc_path):
-      return import_c_file(inc_path)
+        return import_c_file(inc_path)
     else:
-      print("Failed to locate", in_file)
-      exit(1)
+        if not quiet:
+            print("Failed to locate", in_file)
+        exit(1)
 
-def import_c_file(in_file) -> str:
+
+def import_c_file(in_file: str) -> str:
     in_file = os.path.relpath(in_file, root_dir)
-    out_text = ''
+    out_text = ""
 
     try:
-      with open(in_file, encoding="utf-8") as file:
-        out_text += process_file(in_file, list(file))
+        with open(in_file, encoding="utf-8") as file:
+            out_text += process_file(in_file, list(file))
     except Exception:
-      with open(in_file) as file:
-        out_text += process_file(in_file, list(file))
+        with open(in_file) as file:
+            out_text += process_file(in_file, list(file))
     return out_text
 
-def process_file(in_file: str, lines) -> str:
-    out_text = ''
+
+def process_file(in_file: str, lines: list[str]) -> str:
+    out_text = ""
     for idx, line in enumerate(lines):
-      guard_match = guard_pattern.match(line.strip())
-      if idx == 0:
-        if guard_match:
-          if guard_match[1] in defines:
-            break
-          defines.add(guard_match[1])
-        print("Processing file", in_file)
-      include_match = include_pattern.match(line.strip())
-      if include_match and not include_match[1].endswith(".s"):
-        out_text += f"/* \"{in_file}\" line {idx} \"{include_match[1]}\" */\n"
-        out_text += import_h_file(include_match[1], os.path.dirname(in_file))
-        out_text += f"/* end \"{include_match[1]}\" */\n"
-      else:
-        out_text += line
+        guard_match = guard_pattern.match(line.strip())
+        if idx == 0:
+            if guard_match:
+                if guard_match[1] in defines:
+                    break
+                defines.add(guard_match[1])
+            if not quiet:
+                print("Processing file", in_file)
+        include_match = include_pattern.match(line.strip())
+        if include_match and not include_match[1].endswith(".s"):
+            out_text += f'/* "{in_file}" line {idx} "{include_match[1]}" */\n'
+            out_text += import_h_file(include_match[1], os.path.dirname(in_file))
+            out_text += f'/* end "{include_match[1]}" */\n'
+        else:
+            out_text += line
 
     return out_text
 
-def main():
+
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="""Create a context file which can be used for decomp.me"""
     )
@@ -75,12 +82,27 @@ def main():
         "c_file",
         help="""File from which to create context""",
     )
+    parser.add_argument(
+        "--relative",
+        dest="relative",
+        help="Extract context relative to the source file",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--quiet", dest="quiet", help="Don't print anything", action="store_true"
+    )
     args = parser.parse_args()
 
-    output = import_c_file(args.c_file)
+    global quiet
+    quiet = args.quiet
+    c_file = args.c_file
+    content = import_c_file(c_file)
+    filename = (
+        f"{c_file}.ctx" if args.relative else os.path.join(root_dir, "context.ctx")
+    )
 
-    with open(os.path.join(root_dir, "ctx.c"), "w", encoding="utf-8") as f:
-        f.write(output)
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(content)
 
 
 if __name__ == "__main__":

--- a/tools/project.py
+++ b/tools/project.py
@@ -50,6 +50,7 @@ class ProjectConfig:
         self.check_sha_path = None  # Path to version.sha1
         self.config_path = None  # Path to config.yml
         self.debug = False  # Build with debug info
+        self.generate_context = False  # Generate .ctx file(s)
         self.generate_map = False  # Generate map file(s)
         self.ldflags = None  # Linker flags
         self.libs = None  # List of libraries
@@ -340,6 +341,10 @@ def generate_build_ninja(config, build_config):
         mwcc_implicit.append(transform_dep)
         mwcc_sjis_implicit.append(transform_dep)
 
+    if config.generate_context:
+        mwcc_cmd += f" && $python tools/decompctx.py $in --relative --quiet"
+        mwcc_sjis_cmd += f" && $python tools/decompctx.py $in --relative --quiet"
+
     n.comment("Link ELF file")
     n.rule(
         name="link",
@@ -567,6 +572,9 @@ def generate_build_ninja(config, build_config):
                     implicit=path(
                         mwcc_sjis_implicit if options["shiftjis"] else mwcc_implicit
                     ),
+                    implicit_outputs=None
+                    if not config.generate_context
+                    else str(unit_src_path) + ".ctx",
                 )
 
                 if lib["host"]:


### PR DESCRIPTION
Bringing over this QOL from the [Pikmin 2 repo](https://github.com/projectPiki/pikmin2/pull/192). Context files now have these expanded capabilities:
- Can now be integrated into the buildsystem directly, allowing autogeneration of context for each individual file
- Define to ninja as implicitly created, so context can be swiftly removed via `ninja -t cleandead` if desired
- Given a dedicated file extension, both for ease of browsing in file explorer & to entirely remove from VSCode inspector

![image](https://github.com/encounter/dtk-template/assets/17489292/27856e4f-b5b6-4d08-bcba-c21f07fde1c5)
