### PR TITLE
Assembly modding support & objdiff + decomp.me integration

### DIFF
--- a/README.example.md
+++ b/README.example.md
@@ -73,7 +73,7 @@ Linux:
 ------
 - Install [ninja](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages).
 - For non-x86(_64) platforms: Install wine from your package manager.
-  - For x86(_64), [WiBo](https://github.com/decompals/WiBo), a minimal 32-bit Windows binary wrapper, will be automatically downloaded and used.
+  - For x86(_64), [wibo](https://github.com/decompals/wibo), a minimal 32-bit Windows binary wrapper, will be automatically downloaded and used.
 
 Building
 ========

--- a/config/GAMEID/config.example.yml
+++ b/config/GAMEID/config.example.yml
@@ -63,6 +63,11 @@ symbols_known: false
 # this can be set to false.
 fill_gaps: true
 
+# (optional) By default, emitted objects will "export" all symbols (force active).
+# This is useful to prevent the linker from removing any symbols.
+# Individual symbols can be excluded using `noexport` in the symbols file.
+export_all: true
+
 # (optional) Custom template for `ldscript.lcf`. Avoid unless necessary.
 # See https://github.com/encounter/decomp-toolkit/blob/main/assets/ldscript.lcf
 ldscript_template: config/GAMEID/module/ldscript.tpl
@@ -99,7 +104,14 @@ modules:
   # See https://github.com/encounter/decomp-toolkit/blob/main/assets/ldscript_partial.lcf
   ldscript_template: config/GAMEID/module/ldscript.tpl
 
+  # (optional) By default, every REL is linked with every other REL.
+  # Some games link RELs individually, so the module IDs are not unique.
+  # To support this, `links` overrides which other modules are included in this module's analysis.
+  # The DOL is always included, and does not need to be specified.
+  links: [module2] # This module will be linked with the DOL and "module2".
+
 # (optional) Configuration for asset extraction.
+# For modules, this goes in the module's configuration above.
 extract:
 
 - # The symbol name to extract.

--- a/configure.py
+++ b/configure.py
@@ -27,7 +27,7 @@ from tools.project import (
 # Game versions
 DEFAULT_VERSION = 0
 VERSIONS = [
-    "GAMEID",	# 0
+    "GAMEID",  # 0
 ]
 
 if len(VERSIONS) > 1:
@@ -126,9 +126,9 @@ if not is_windows():
 # Tool versions
 config.binutils_tag = "2.41-1"
 config.compilers_tag = "20231018"
-config.dtk_tag = "v0.6.2"
+config.dtk_tag = "v0.7.2"
 config.sjiswrap_tag = "v1.1.1"
-config.wibo_tag = "0.6.9"
+config.wibo_tag = "0.6.11"
 
 # Project
 config.config_path = Path("config") / config.version / "config.yml"
@@ -137,7 +137,7 @@ config.asflags = [
     "-mgekko",
     # "-W",
     "--strip-local-absolute",
-    "-gdwarf-2",
+    # "-gdwarf-2",
     "-I include",
     f"-I build/{config.version}/include",
     f"--defsym version={version_num}",
@@ -167,7 +167,7 @@ cflags_base = [
     "-RTTI off",
     "-fp_contract on",
     "-str reuse",
-	"-multibyte", # For Wii compilers, replace with `-enc SJIS`
+    "-multibyte",  # For Wii compilers, replace with `-enc SJIS`
     "-i include",
     f"-i build/{config.version}/include",
     f"-DVERSION={version_num}",
@@ -186,7 +186,7 @@ cflags_runtime = [
     "-str reuse,pool,readonly",
     "-gccinc",
     "-common off",
-	"-inline auto",
+    "-inline auto",
 ]
 
 # REL flags

--- a/configure.py
+++ b/configure.py
@@ -56,6 +56,12 @@ parser.add_argument(
     help="base build directory (default: build)",
 )
 parser.add_argument(
+    "--binutils",
+    dest="binutils",
+    type=Path,
+    help="path to binutils (optional)",
+)
+parser.add_argument(
     "--compilers",
     dest="compilers",
     type=Path,
@@ -109,6 +115,7 @@ version_num = VERSIONS.index(config.version)
 # Apply arguments
 config.build_dir = args.build_dir
 config.build_dtk_path = args.build_dtk
+config.binutils_path = args.binutils
 config.compilers_path = args.compilers
 config.debug = args.debug
 config.generate_map = args.map
@@ -117,6 +124,7 @@ if not is_windows():
     config.wrapper = args.wrapper
 
 # Tool versions
+config.binutils_tag = "2.41-1"
 config.compilers_tag = "20231018"
 config.dtk_tag = "v0.6.2"
 config.sjiswrap_tag = "v1.1.1"
@@ -125,6 +133,15 @@ config.wibo_tag = "0.6.9"
 # Project
 config.config_path = Path("config") / config.version / "config.yml"
 config.check_sha_path = Path("config") / config.version / "build.sha1"
+config.asflags = [
+    "-mgekko",
+    # "-W",
+    "--strip-local-absolute",
+    "-gdwarf-2",
+    "-I include",
+    f"-I build/{config.version}/include",
+    f"--defsym version={version_num}",
+]
 config.ldflags = [
     "-fp hardware",
     "-nodefaults",

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,6 +1,8 @@
-# Dependencies
+Dependencies
+============
 
-## Windows:
+Windows:
+--------
 
 On Windows, it's **highly recommended** to use native tooling. WSL or msys2 are **not** required.  
 When running under WSL, [objdiff](#diffing) is unable to get filesystem notifications for automatic rebuilds.
@@ -10,8 +12,8 @@ When running under WSL, [objdiff](#diffing) is unable to get filesystem notifica
 - Download [ninja](https://github.com/ninja-build/ninja/releases) and add it to `%PATH%`.
   - Quick install via pip: `pip install ninja`
 
-## macOS:
-
+macOS:
+------
 - Install [ninja](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages):
   ```
   brew install ninja
@@ -26,8 +28,8 @@ After OS upgrades, if macOS complains about `Wine Crossover.app` being unverifie
 sudo xattr -rd com.apple.quarantine '/Applications/Wine Crossover.app'
 ```
 
-## Linux:
-
+Linux:
+------
 - Install [ninja](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages).
 - For non-x86(_64) platforms: Install wine from your package manager.
-  - For x86(_64), [WiBo](https://github.com/decompals/WiBo), a minimal 32-bit Windows binary wrapper, will be automatically downloaded and used.
+  - For x86(_64), [wibo](https://github.com/decompals/wibo), a minimal 32-bit Windows binary wrapper, will be automatically downloaded and used.

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -33,3 +33,5 @@ All attributes are optional, and are separated by spaces.
 - `hidden` Marked as "hidden" in the generated object. (Only used for extab)
 - `force_active` Marked as ["exported"](comment_section.md) in the generated object, and added to `FORCEACTIVE` in the generated `ldscript.lcf`. Prevents the symbol from being deadstripped.
 - `noreloc` Prevents the _contents_ of the symbol from being interpreted as addresses. Used for objects containing data that look like pointers, but aren't.
+- `noexport` When `export_all` is enabled, this excludes the symbol from being exported. Used for symbols that are affected by linker `-code_merging`.
+- `stripped` Indicates a symbol that was stripped by the linker. Used for symbols that affect the [common BSS inflation bug](common_bss.md), despite not existing in the final binary.

--- a/tools/decompctx.py
+++ b/tools/decompctx.py
@@ -20,52 +20,56 @@ src_dir = os.path.join(root_dir, "src")
 include_dir = os.path.join(root_dir, "include")
 
 include_pattern = re.compile(r'^#include\s*[<"](.+?)[>"]$')
-guard_pattern = re.compile(r'^#ifndef\s+(.*)$')
+guard_pattern = re.compile(r"^#ifndef\s+(.*)$")
 
 defines = set()
+
 
 def import_h_file(in_file: str, r_path: str) -> str:
     rel_path = os.path.join(root_dir, r_path, in_file)
     inc_path = os.path.join(include_dir, in_file)
     if os.path.exists(rel_path):
-      return import_c_file(rel_path)
+        return import_c_file(rel_path)
     elif os.path.exists(inc_path):
-      return import_c_file(inc_path)
+        return import_c_file(inc_path)
     else:
-      print("Failed to locate", in_file)
-      exit(1)
+        print("Failed to locate", in_file)
+        exit(1)
+
 
 def import_c_file(in_file) -> str:
     in_file = os.path.relpath(in_file, root_dir)
-    out_text = ''
+    out_text = ""
 
     try:
-      with open(in_file, encoding="utf-8") as file:
-        out_text += process_file(in_file, list(file))
+        with open(in_file, encoding="utf-8") as file:
+            out_text += process_file(in_file, list(file))
     except Exception:
-      with open(in_file) as file:
-        out_text += process_file(in_file, list(file))
+        with open(in_file) as file:
+            out_text += process_file(in_file, list(file))
     return out_text
+
 
 def process_file(in_file: str, lines) -> str:
-    out_text = ''
+    out_text = ""
     for idx, line in enumerate(lines):
-      guard_match = guard_pattern.match(line.strip())
-      if idx == 0:
-        if guard_match:
-          if guard_match[1] in defines:
-            break
-          defines.add(guard_match[1])
-        print("Processing file", in_file)
-      include_match = include_pattern.match(line.strip())
-      if include_match and not include_match[1].endswith(".s"):
-        out_text += f"/* \"{in_file}\" line {idx} \"{include_match[1]}\" */\n"
-        out_text += import_h_file(include_match[1], os.path.dirname(in_file))
-        out_text += f"/* end \"{include_match[1]}\" */\n"
-      else:
-        out_text += line
+        guard_match = guard_pattern.match(line.strip())
+        if idx == 0:
+            if guard_match:
+                if guard_match[1] in defines:
+                    break
+                defines.add(guard_match[1])
+            print("Processing file", in_file)
+        include_match = include_pattern.match(line.strip())
+        if include_match and not include_match[1].endswith(".s"):
+            out_text += f'/* "{in_file}" line {idx} "{include_match[1]}" */\n'
+            out_text += import_h_file(include_match[1], os.path.dirname(in_file))
+            out_text += f'/* end "{include_match[1]}" */\n'
+        else:
+            out_text += line
 
     return out_text
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -75,11 +79,17 @@ def main():
         "c_file",
         help="""File from which to create context""",
     )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="""Output file""",
+        default="ctx.c",
+    )
     args = parser.parse_args()
 
     output = import_c_file(args.c_file)
 
-    with open(os.path.join(root_dir, "ctx.c"), "w", encoding="utf-8") as f:
+    with open(os.path.join(root_dir, args.output), "w", encoding="utf-8") as f:
         f.write(output)
 
 

--- a/tools/download_tool.py
+++ b/tools/download_tool.py
@@ -22,6 +22,24 @@ import zipfile
 from pathlib import Path
 
 
+def binutils_url(tag):
+    uname = platform.uname()
+    system = uname.system.lower()
+    arch = uname.machine.lower()
+    if system == "darwin":
+        system = "macos"
+        arch = "universal"
+    elif arch == "amd64":
+        arch = "x86_64"
+
+    repo = "https://github.com/encounter/gc-wii-binutils"
+    return f"{repo}/releases/download/{tag}/{system}-{arch}.zip"
+
+
+def compilers_url(tag):
+    return f"https://files.decomp.dev/compilers_{tag}.zip"
+
+
 def dtk_url(tag):
     uname = platform.uname()
     suffix = ""
@@ -48,15 +66,12 @@ def wibo_url(tag):
     return f"{repo}/releases/download/{tag}/wibo"
 
 
-def compilers_url(tag):
-    return f"https://files.decomp.dev/compilers_{tag}.zip"
-
-
 TOOLS = {
+    "binutils": binutils_url,
+    "compilers": compilers_url,
     "dtk": dtk_url,
     "sjiswrap": sjiswrap_url,
     "wibo": wibo_url,
-    "compilers": compilers_url,
 }
 
 
@@ -77,7 +92,11 @@ def main():
             data = io.BytesIO(response.read())
             with zipfile.ZipFile(data) as f:
                 f.extractall(output)
-            output.touch(mode=0o755)
+            # Make all files executable
+            for root, _, files in os.walk(output):
+                for name in files:
+                    os.chmod(os.path.join(root, name), 0o755)
+            output.touch(mode=0o755)  # Update dir modtime
         else:
             with open(output, "wb") as f:
                 shutil.copyfileobj(response, f)


### PR DESCRIPTION
Monolithic PR because this is merging 4 different sets of changes together.

- Assembly modding support
  - Place an .s in `asm` dir, and it will override the extracted object.
  - Place an .s in `src` to have it be treated as if it were a matching C file (e.g. for TUs that were originally asm)
- decomp.me support in objdiff (**NOTE**: won't work until objdiff 1.0.1+)
- Custom REL links handling created for [mp4-dtk](https://github.com/Rainchus/mp4-dtk)