### PR TITLE
Allow adding re-configure dependencies and doing non-matching builds

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -105,6 +105,12 @@ parser.add_argument(
     action="store_true",
     help="print verbose output",
 )
+parser.add_argument(
+    "--non-matching",
+    dest="non_matching",
+    action="store_true",
+    help="builds equivalent (but non-matching) or modded objects",
+)
 args = parser.parse_args()
 
 config = ProjectConfig()
@@ -118,6 +124,7 @@ config.binutils_path = args.binutils
 config.compilers_path = args.compilers
 config.debug = args.debug
 config.generate_map = args.map
+config.non_matching = args.non_matching
 config.sjiswrap_path = args.sjiswrap
 if not is_windows():
     config.wrapper = args.wrapper
@@ -222,8 +229,9 @@ def Rel(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
     }
 
 
-Matching = True
-NonMatching = False
+Matching = True                   # Object matches and should be linked
+NonMatching = False               # Object does not match and should not be linked
+Equivalent = config.non_matching  # Object should be linked when configured with --non-matching
 
 config.warn_missing_config = True
 config.warn_missing_source = False

--- a/configure.py
+++ b/configure.py
@@ -154,7 +154,7 @@ config.ldflags = [
     # "-listclosure", # Uncomment for Wii linkers
 ]
 # Use for any additional files that should cause a re-configure when modified
-# config.reconfig_deps = []
+config.reconfig_deps = []
 
 # Base flags, common to most GC/Wii games.
 # Generally leave untouched, with overrides added below.

--- a/configure.py
+++ b/configure.py
@@ -108,7 +108,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 config = ProjectConfig()
-config.version = args.version
+config.version = str(args.version)
 version_num = VERSIONS.index(config.version)
 
 # Apply arguments

--- a/configure.py
+++ b/configure.py
@@ -146,6 +146,8 @@ config.ldflags = [
     "-nodefaults",
     # "-listclosure", # Uncomment for Wii linkers
 ]
+# Use for any additional files that should cause a re-configure when modified
+# config.reconfig_deps = []
 
 # Base flags, common to most GC/Wii games.
 # Generally leave untouched, with overrides added below.

--- a/tools/project.py
+++ b/tools/project.py
@@ -71,6 +71,7 @@ class ProjectConfig:
         self.sjiswrap_path: Optional[Path] = None  # If None, download
 
         # Project config
+        self.non_matching: bool = False
         self.build_rels: bool = True  # Build REL files
         self.check_sha_path: Optional[Path] = None  # Path to version.sha1
         self.config_path: Optional[Path] = None  # Path to config.yml
@@ -862,7 +863,7 @@ def generate_build_ninja(
         )
         n.build(
             outputs=ok_path,
-            rule="check",
+            rule="phony" if config.non_matching else "check",
             inputs=config.check_sha_path,
             implicit=[dtk, *map(lambda step: step.output(), link_steps)],
         )
@@ -879,7 +880,7 @@ def generate_build_ninja(
         )
         n.build(
             outputs=progress_path,
-            rule="progress",
+            rule="phony" if config.non_matching else "progress",
             implicit=[ok_path, configure_script, python_lib, config.config_path],
         )
 

--- a/tools/project.py
+++ b/tools/project.py
@@ -90,6 +90,9 @@ class ProjectConfig:
         self.shift_jis = (
             True  # Convert source files from UTF-8 to Shift JIS automatically
         )
+        self.reconfig_deps: Optional[List[Path]] = (
+            None  # Additional re-configuration dependency files
+        )
 
         # Progress output and progress.json config
         self.progress_all: bool = True  # Include combined "all" category
@@ -961,6 +964,7 @@ def generate_build_ninja(
             configure_script,
             python_lib,
             python_lib_dir / "ninja_syntax.py",
+            *(config.reconfig_deps or [])
         ],
     )
     n.newline()


### PR DESCRIPTION
Additional re-configure dependencies can now be added in the project config. For example, for [rb3](https://github.com/DarkRTA/rb3), we moved object configuration to a pair of [`objects.json`](https://github.com/DarkRTA/rb3/blob/master/config/SZBE69_B8/objects.json) and [`flags.json`](https://github.com/DarkRTA/rb3/blob/master/config/SZBE69_B8/flags.json) files so we can configure things per-version, and edits to these files need to cause a re-configure.

Additionally, a non-matching build can now be performed by passing the `--non-matching` argument to configure.py. This skips the hash check and progress output, since those don't make sense to run in this configuration. A new `Equivalent` object status has also been added, which will make an object be built and linked only in this configuration.

I also fixed a small type-checking issue in configure.py, `config.version` was still an `Optional[str]` after being set from args.