### PR TITLE
Allow spaces after '#' when creating decomp context

### DIFF
--- a/tools/decompctx.py
+++ b/tools/decompctx.py
@@ -23,8 +23,8 @@ include_dirs = [
     # Add additional include directories here
 ]
 
-include_pattern = re.compile(r'^#include\s*[<"](.+?)[>"]$')
-guard_pattern = re.compile(r"^#ifndef\s+(.*)$")
+include_pattern = re.compile(r'^#\s*include\s*[<"](.+?)[>"]$')
+guard_pattern = re.compile(r"^#\s*ifndef\s+(.*)$")
 
 defines = set()
 


### PR DESCRIPTION
It's possible for preprocessor statements to include whitespace between the `#` and directive, which I encountered with some ps2 library headers. This updates the include and guard regexes to allow whitespace there.