### PR TITLE
Move conditional linker flag additions from project.py to configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -178,10 +178,17 @@ cflags_base = [
     f"-DVERSION={version_num}",
 ]
 
-# Debug flags
+# Conditionally-added flags
+if config.generate_map:
+    # List unused symbols when generating a map file
+    config.ldflags.append("-mapunused")
+
 if config.debug:
+    # Debug flags
     cflags_base.extend(["-sym on", "-DDEBUG=1"])
+    config.ldflags.append("-g")
 else:
+    # No-debug flags
     cflags_base.append("-DNDEBUG=1")
 
 # Metrowerks library flags

--- a/tools/project.py
+++ b/tools/project.py
@@ -131,7 +131,6 @@ class ProjectConfig:
         self.build_rels: bool = True  # Build REL files
         self.check_sha_path: Optional[Path] = None  # Path to version.sha1
         self.config_path: Optional[Path] = None  # Path to config.yml
-        self.debug: bool = False  # Build with debug info
         self.generate_map: bool = False  # Generate map file(s)
         self.asflags: Optional[List[str]] = None  # Assembler flags
         self.ldflags: Optional[List[str]] = None  # Linker flags

--- a/tools/project.py
+++ b/tools/project.py
@@ -283,12 +283,7 @@ def generate_build_ninja(
     # Variables
     ###
     n.comment("Variables")
-    ldflags = " ".join(config.ldflags or [])
-    if config.generate_map:
-        ldflags += " -mapunused"
-    if config.debug:
-        ldflags += " -g"
-    n.variable("ldflags", ldflags)
+    n.variable("ldflags", " ".join(config.ldflags or []))
     if config.linker_version is None:
         sys.exit("ProjectConfig.linker_version missing")
     n.variable("mw_version", Path(config.linker_version))


### PR DESCRIPTION
Ensures that no per-project modifications of project.py need to be done if either debug info or map generation require different flags (e.g. DWARF-2 using `-gdwarf-2` instead of `-g`).

Supersedes #34 as a more flexible alternative.