### PR TITLE
Don't show objects as diffable in objdiff if a source file doesn't exist

### DIFF
--- a/tools/project.py
+++ b/tools/project.py
@@ -1386,7 +1386,7 @@ def generate_objdiff_config(
             progress_categories.append(category_opt)
         unit_config["metadata"].update(
             {
-                "complete": obj.completed,
+                "complete": obj.completed if src_exists else None,
                 "reverse_fn_order": reverse_fn_order,
                 "progress_categories": progress_categories,
             }


### PR DESCRIPTION
Somewhat recently in rb3 we filled in our objects list with every file in our splits.txt, so that we didn't have to put in file paths every time a new file was started, and so that we could re-enable `config.warn_missing_config`. A side-effect of this is that objects in objdiff would always show as red/diffable, even when the corresponding source file is missing. This change fixes that, so that unstarted objects can be distinguished directly at a glance.

This could also be done as a fix on objdiff's side of things, where it ignores the `completed` metadata if the specified source file doesn't exist, but that would require a lot of IO polling to check that on each config load, which could slow things somewhat notably.