### PR TITLE
Adjust version defines to avoid name collisions and improve usage ergonomics

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -158,6 +158,7 @@ config.asflags = [
     "-I include",
     f"-I build/{config.version}/include",
     f"--defsym BUILD_VERSION={version_num}",
+    f"--defsym VERSION_{config.version}",
 ]
 config.ldflags = [
     "-fp hardware",
@@ -199,6 +200,7 @@ cflags_base = [
     "-i include",
     f"-i build/{config.version}/include",
     f"-DBUILD_VERSION={version_num}",
+    f"-DVERSION_{config.version}",
 ]
 
 # Debug flags

--- a/configure.py
+++ b/configure.py
@@ -157,7 +157,7 @@ config.asflags = [
     "--strip-local-absolute",
     "-I include",
     f"-I build/{config.version}/include",
-    f"--defsym version={version_num}",
+    f"--defsym BUILD_VERSION={version_num}",
 ]
 config.ldflags = [
     "-fp hardware",
@@ -198,7 +198,7 @@ cflags_base = [
     "-multibyte",  # For Wii compilers, replace with `-enc SJIS`
     "-i include",
     f"-i build/{config.version}/include",
-    f"-DVERSION={version_num}",
+    f"-DBUILD_VERSION={version_num}",
 ]
 
 # Debug flags


### PR DESCRIPTION
The `VERSION` define is now `BUILD_VERSION`, and each version now has a unique define under the format `VERSION_GAMEID`, where `GAMEID` is the version string specified in configure.py.

Now, both of these are equivalent with the stock configure.py:

```cpp
#if BUILD_VERSION == 0
    ...
#endif

#ifdef VERSION_GAMEID
    ...
#endif
```