### PR TITLE
ninja changes: Fix old Python version compatibility

### DIFF
--- a/tools/changes_fmt.py
+++ b/tools/changes_fmt.py
@@ -22,7 +22,7 @@ FUNCTION_KEYS_TO_DIFF = [
     "fuzzy_match_percent",
 ]
 
-type Change = Tuple[str, str, float, float]
+Change = Tuple[str, str, float, float]
 
 
 def get_changes(changes_file: str) -> list[Change]:


### PR DESCRIPTION
Didn't realize this type hinting syntax was Python 3.12+ only, this change should allow changes_fmt.py to run on Python 3.6+.