### PR TITLE
Allow customizing progress report config arguments

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -144,10 +144,10 @@ if not config.non_matching:
 # Tool versions
 config.binutils_tag = "2.42-1"
 config.compilers_tag = "20240706"
-config.dtk_tag = "v1.4.1"
-config.objdiff_tag = "v2.7.1"
-config.sjiswrap_tag = "v1.2.0"
-config.wibo_tag = "0.6.11"
+config.dtk_tag = "v1.5.1"
+config.objdiff_tag = "v3.0.0-beta.8"
+config.sjiswrap_tag = "v1.2.1"
+config.wibo_tag = "0.6.16"
 
 # Project
 config.config_path = Path("config") / config.version / "config.yml"

--- a/configure.py
+++ b/configure.py
@@ -301,6 +301,10 @@ config.progress_categories = [
     ProgressCategory("sdk", "SDK Code"),
 ]
 config.progress_each_module = args.verbose
+# Optional extra arguments to `objdiff-cli report generate`
+config.progress_report_args = [
+    "--config functionRelocDiffs=data_value",  # Enables diffing functions by their relocations and data
+]
 
 if args.mode == "configure":
     # Write build.ninja and objdiff.json

--- a/tools/project.py
+++ b/tools/project.py
@@ -206,6 +206,9 @@ class ProjectConfig:
         self.print_progress_categories: Union[bool, List[str]] = (
             True  # Print additional progress categories in the CLI progress output
         )
+        self.progress_report_args: Optional[List[str]] = (
+            None  # Flags to `objdiff-cli report generate`
+        )
 
         # Progress fancy printing
         self.progress_use_fancy: bool = False
@@ -422,6 +425,7 @@ def generate_build_ninja(
     if config.linker_version is None:
         sys.exit("ProjectConfig.linker_version missing")
     n.variable("mw_version", Path(config.linker_version))
+    n.variable("objdiff_report_args", make_flags_str(config.progress_report_args))
     n.newline()
 
     ###
@@ -1203,7 +1207,7 @@ def generate_build_ninja(
         n.comment("Generate progress report")
         n.rule(
             name="report",
-            command=f"{objdiff} report generate -o $out",
+            command=f"{objdiff} report generate $objdiff_report_args -o $out",
             description="REPORT",
         )
         n.build(


### PR DESCRIPTION
This adds a new config field that can be set to pass extra arguments to `objdiff-cli report generate` to customize how progress reports are generated.

I changed the template configure.py to pass `--config functionRelocDiffs=data_value` by default which I think should work well for projects with symbol maps. Unsure about ones without maps though. If we don't want to change the default, maybe we could just leave this line commented out so it serves as an example of how to use it.

This requires the objdiff 3 beta to work, so I went ahead and updated all the other tags while I was at it. sjiswrap 1.2.1 isn't released yet so this PR shouldn't be merged until then. The wibo bug that broke newer versions of it was apparently fixed at some point so that seems to work fine now.