### PR TITLE
Add --warn argument to configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -114,6 +114,13 @@ parser.add_argument(
     help="builds equivalent (but non-matching) or modded objects",
 )
 parser.add_argument(
+    "--warn",
+    dest="warn",
+    type=str,
+    choices=["all", "off", "error"],
+    help="how to handle warnings",
+)
+parser.add_argument(
     "--no-progress",
     dest="progress",
     action="store_false",
@@ -208,6 +215,14 @@ if args.debug:
     cflags_base.extend(["-sym on", "-DDEBUG=1"])
 else:
     cflags_base.append("-DNDEBUG=1")
+
+# Warning flags
+if args.warn == "all":
+    cflags_base.append("-W all")
+elif args.warn == "off":
+    cflags_base.append("-W off")
+elif args.warn == "error":
+    cflags_base.append("-W error")
 
 # Metrowerks library flags
 cflags_runtime = [

--- a/tools/project.py
+++ b/tools/project.py
@@ -1213,7 +1213,7 @@ def generate_build_ninja(
         n.build(
             outputs=report_path,
             rule="report",
-            implicit=[objdiff, "all_source"],
+            implicit=[objdiff, "objdiff.json", "all_source"],
             order_only="post-build",
         )
 
@@ -1367,7 +1367,7 @@ def generate_build_ninja(
         description=f"RUN {configure_script}",
     )
     n.build(
-        outputs="build.ninja",
+        outputs=["build.ninja", "objdiff.json"],
         rule="configure",
         implicit=[
             build_config_path,


### PR DESCRIPTION
(And unrelated but also added a new implicit since I noticed report.json becomes outdated if you only link/unlink TUs without changing any code, which can make `ninja changes` slightly confusing)