### PR TITLE
Replace object-level clean_extab with extab_padding

### DIFF
--- a/config/GAMEID/config.example.yml
+++ b/config/GAMEID/config.example.yml
@@ -102,6 +102,9 @@ ldscript_template: config/GAMEID/module/ldscript.tpl
 # the uninitialized data zeroed out. When targeting a cleaned DOL hash,
 # this option can be set to true to scrub the uninitialized data from 
 # the extab section in the split objects.
+#
+# Alternatively, you can set extab_padding on any affected objects in
+# configure.py, in order to exactly match the original DOL.
 clean_extab: false
 
 # (optional) Configuration for modules.

--- a/configure.py
+++ b/configure.py
@@ -151,7 +151,7 @@ if not config.non_matching:
 # Tool versions
 config.binutils_tag = "2.42-1"
 config.compilers_tag = "20250520"
-config.dtk_tag = "v1.6.0"
+config.dtk_tag = "v1.6.1"
 config.objdiff_tag = "v3.0.0-beta.8"
 config.sjiswrap_tag = "v1.2.1"
 config.wibo_tag = "0.6.16"


### PR DESCRIPTION
This hooks up https://github.com/encounter/decomp-toolkit/pull/103 in project.py.

Instead of `clean_extab=True`, you can write `extab_padding = []` to get the previous behavior. The project-wide `clean_extab` option still exists, though.
