### PR TITLE
Add support for excluded globs and prelude macros to decompctx.py

### DIFF
--- a/tools/decompctx.py
+++ b/tools/decompctx.py
@@ -31,17 +31,18 @@ deps = []
 
 
 def generate_prelude(defines) -> str:
-    out_text = ""
-    if len(defines) > 0:
-        out_text += "/* decompctx prelude */\n"
+    if len(defines) == 0:
+        return ""
+
+    out_text = "/* decompctx prelude */\n"
     for define in defines:
-        if define.count("=") > 0:
-            macro_name, macro_val = define.split("=", 1)
+        parts = define.split("=", 1)
+        if len(parts) == 2:
+            macro_name, macro_val = parts
             out_text += f"#define {macro_name} {macro_val}\n"
         else:
-            out_text += f"#define {define}\n"
-    if len(defines) > 0:
-        out_text += "/* end decompctx prelude */\n\n"
+            out_text += f"#define {parts[0]}\n"
+    out_text += "/* end decompctx prelude */\n\n"
 
     return out_text
 
@@ -74,7 +75,6 @@ def import_c_file(in_file: str) -> str:
 
 
 def process_file(in_file: str, lines: List[str]) -> str:
-    print(f"process_file: {in_file}")
     out_text = ""
     for idx, line in enumerate(lines):
         if idx == 0:
@@ -100,7 +100,7 @@ def process_file(in_file: str, lines: List[str]) -> str:
 
             out_text += f'/* "{in_file}" line {idx} "{include_match[1]}" */\n'
             if excluded:
-                out_text += f'/* Skipped excluded file */\n'
+                out_text += "/* Skipped excluded file */\n"
             else:
                 out_text += import_h_file(include_match[1], os.path.dirname(in_file))
             out_text += f'/* end "{include_match[1]}" */\n'

--- a/tools/project.py
+++ b/tools/project.py
@@ -198,11 +198,11 @@ class ProjectConfig:
         self.link_order_callback: Optional[Callable[[int, List[str]], List[str]]] = (
             None  # Callback to add/remove/reorder units within a module
         )
-        self.context_exclude_globs: Optional[List[str]] = (
-            None  # Globs to exclude from context files
+        self.context_exclude_globs: List[str] = (
+            []  # Globs to exclude from context files
         )
-        self.context_defines: Optional[List[str]] = (
-            None  # Macros to define at the top of context files
+        self.context_defines: List[str] = (
+            []  # Macros to define at the top of context files
         )
 
         # Progress output and report.json config
@@ -1054,11 +1054,8 @@ def generate_build_ninja(
                     ):
                         include_dirs.append(flag[3:])
                 includes = " ".join([f"-I {d}" for d in include_dirs])
-
-                excludes = " ".join(
-                    [f"-x {d}" for d in config.context_exclude_globs] if config.context_exclude_globs else [])
-
-                defines = " ".join([f"-D {d}" for d in config.context_defines] if config.context_defines else [])
+                excludes = " ".join([f"-x {d}" for d in config.context_exclude_globs])
+                defines = " ".join([f"-D {d}" for d in config.context_defines])
 
                 n.build(
                     outputs=obj.ctx_path,

--- a/tools/project.py
+++ b/tools/project.py
@@ -198,6 +198,12 @@ class ProjectConfig:
         self.link_order_callback: Optional[Callable[[int, List[str]], List[str]]] = (
             None  # Callback to add/remove/reorder units within a module
         )
+        self.context_exclude_globs: Optional[List[str]] = (
+            None  # Globs to exclude from context files
+        )
+        self.context_defines: Optional[List[str]] = (
+            None  # Macros to define at the top of context files
+        )
 
         # Progress output and report.json config
         self.progress = True  # Enable report.json generation and CLI progress output
@@ -492,7 +498,7 @@ def generate_build_ninja(
     decompctx = config.tools_dir / "decompctx.py"
     n.rule(
         name="decompctx",
-        command=f"$python {decompctx} $in -o $out -d $out.d $includes",
+        command=f"$python {decompctx} $in -o $out -d $out.d $includes $excludes $defines",
         description="CTX $in",
         depfile="$out.d",
         deps="gcc",
@@ -1048,12 +1054,22 @@ def generate_build_ninja(
                     ):
                         include_dirs.append(flag[3:])
                 includes = " ".join([f"-I {d}" for d in include_dirs])
+
+                excludes = " ".join(
+                    [f"-x {d}" for d in config.context_exclude_globs] if config.context_exclude_globs else [])
+
+                defines = " ".join([f"-D {d}" for d in config.context_defines] if config.context_defines else [])
+
                 n.build(
                     outputs=obj.ctx_path,
                     rule="decompctx",
                     inputs=src_path,
                     implicit=decompctx,
-                    variables={"includes": includes},
+                    variables={
+                        "includes": includes,
+                        "excludes": excludes,
+                        "defines": defines,
+                    },
                 )
             n.newline()
 


### PR DESCRIPTION
This PR adds two new features to `decompctx.py`:

### Excluded glob patterns

This adds a new `-x`/`--exclude` CLI flag which is used to specify glob patterns to be excluded when resolving includes. This is especially relevant to projects using precompiled headers as currently the script will choke on any file which directly includes a `.mch` file and not emit anything.

### Prelude macros

This adds a new `-D`/`--define` CLI flag which is used to provide macro definitions which will be emitted in a prelude before the file content. This again is relevant to PCH projects as it would be useful for conditionally compiling code which only functions properly when built into a PCH. As an example, the `sqrtf` constants in Twilight Princess wreak havoc because they're incorrectly placed in `.rodata` instead of `.data` which has a variety of knock-on effects in the assembly. This can be mitigated by making them into local constants instead of `static` ones.

---

This PR also adds support for the new features to `project.py` in the form of two new config keys: `context_exclude_globs` and `context_defines`.