### PR TITLE
Normalize build.ninja paths to forward slashes for Windows+MSYS2

### DIFF
--- a/tools/project.py
+++ b/tools/project.py
@@ -1543,8 +1543,14 @@ def generate_build_ninja(
         n.default(build_config_path)
 
     # Write build.ninja
+    ninja_text = out.getvalue()
+    # Fix: on Windows+MSYS2, /bin/sh interprets backslashes in paths as
+    # escape characters (e.g. backslash followed by 0 becomes a NUL escape).
+    # Normalize all paths in build.ninja to forward slashes -- Windows tools
+    # accept both, and bash leaves them alone.
+    ninja_text = ninja_text.replace(chr(92), "/")
     with open("build.ninja", "w", encoding="utf-8") as f:
-        f.write(out.getvalue())
+        f.write(ninja_text)
     out.close()
 
 


### PR DESCRIPTION
## Summary

When ninja is invoked under MSYS2 / Git Bash on Windows, the `/bin/sh` that ninja uses for its `command =` rules interprets backslashes in paths as escape characters. Path components like `build/compilers/Wii\0x4201_127/mwcceppc.exe` get mangled because `\0` is read as a NUL escape — the rest of the path is silently truncated and the build fails with `mwcceppc.exe: No such file or directory`.

This patch replaces all backslashes in the generated `build.ninja` with forward slashes after the file is built. The Windows tools used by decomp builds (`mwcceppc.exe`, `mwldeppc.exe`, `dtk.exe`) all accept both separators, and Linux/macOS builds are unaffected since they don't generate backslashes in the first place.

## Reproduction

Building any decomp project that uses `dtk-template` on Windows under Git Bash / MSYS2 reproduces the issue:

```
$ ninja
[8/210] MWCC 'build\RMCP01\src\util\Random.o'
FAILED: [code=127] build\RMCP01\src\util\Random.o
build/compilers/Wii\0x4201_127/mwcceppc.exe ...
/bin/sh: line 1: build/compilers/Wii0x4201_127/mwcceppc.exe: No such file or directory
```

After the fix, `build.ninja` contains `Wii/0x4201_127/mwcceppc.exe` (forward slash) and the build completes correctly.

## Test plan

- [x] Tested locally on Windows 11 + MSYS2 + Git Bash, building riidefi/mkw end-to-end
- [x] Resulting `main.dol` and `StaticR.rel` sha1 unchanged (proves no semantic build difference)
- Linux/macOS: No change in behavior — `os.sep` is already `/` so the replace is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)